### PR TITLE
Add services for Donation, Kontakt, and Om models

### DIFF
--- a/ForeningWeb/Data/ApplicationDbContext.cs
+++ b/ForeningWeb/Data/ApplicationDbContext.cs
@@ -13,5 +13,6 @@ namespace ForeningWeb.Data
         public DbSet<Event> Events { get; set; }
         public DbSet<Om> Om { get; set; }
         public DbSet<Kontakt> Kontakter { get; set; }
+        public DbSet<Donation> Donationer { get; set; }
     }
 }

--- a/ForeningWeb/Services/DonationService.cs
+++ b/ForeningWeb/Services/DonationService.cs
@@ -1,0 +1,45 @@
+using ForeningWeb.Data;
+using ForeningWeb.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ForeningWeb.Services
+{
+    public class DonationService
+    {
+        private readonly ApplicationDbContext _db;
+
+        public DonationService(ApplicationDbContext db)
+        {
+            _db = db;
+        }
+
+        public Task<Donation?> FindAsync(int id) =>
+            _db.Donationer.FindAsync(id).AsTask();
+
+        public async Task<int> CreateAsync(Donation d)
+        {
+            _db.Donationer.Add(d);
+            await _db.SaveChangesAsync();
+            return d.Id;
+        }
+
+        public async Task UpdateAsync(Donation d)
+        {
+            _db.Donationer.Update(d);
+            await _db.SaveChangesAsync();
+        }
+
+        public Task<List<Donation>> GetAllAsync() =>
+            _db.Donationer.ToListAsync();
+
+        public async Task DeleteAsync(int id)
+        {
+            var d = await _db.Donationer.FindAsync(id);
+            if (d != null)
+            {
+                _db.Donationer.Remove(d);
+                await _db.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/ForeningWeb/Services/KontaktService.cs
+++ b/ForeningWeb/Services/KontaktService.cs
@@ -1,0 +1,45 @@
+using ForeningWeb.Data;
+using ForeningWeb.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ForeningWeb.Services
+{
+    public class KontaktService
+    {
+        private readonly ApplicationDbContext _db;
+
+        public KontaktService(ApplicationDbContext db)
+        {
+            _db = db;
+        }
+
+        public Task<Kontakt?> FindAsync(int id) =>
+            _db.Kontakter.FindAsync(id).AsTask();
+
+        public async Task<int> CreateAsync(Kontakt k)
+        {
+            _db.Kontakter.Add(k);
+            await _db.SaveChangesAsync();
+            return k.Id;
+        }
+
+        public async Task UpdateAsync(Kontakt k)
+        {
+            _db.Kontakter.Update(k);
+            await _db.SaveChangesAsync();
+        }
+
+        public Task<List<Kontakt>> GetAllAsync() =>
+            _db.Kontakter.ToListAsync();
+
+        public async Task DeleteAsync(int id)
+        {
+            var k = await _db.Kontakter.FindAsync(id);
+            if (k != null)
+            {
+                _db.Kontakter.Remove(k);
+                await _db.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/ForeningWeb/Services/OmService.cs
+++ b/ForeningWeb/Services/OmService.cs
@@ -1,0 +1,45 @@
+using ForeningWeb.Data;
+using ForeningWeb.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ForeningWeb.Services
+{
+    public class OmService
+    {
+        private readonly ApplicationDbContext _db;
+
+        public OmService(ApplicationDbContext db)
+        {
+            _db = db;
+        }
+
+        public Task<Om?> FindAsync(int id) =>
+            _db.Om.FindAsync(id).AsTask();
+
+        public async Task<int> CreateAsync(Om o)
+        {
+            _db.Om.Add(o);
+            await _db.SaveChangesAsync();
+            return o.Id;
+        }
+
+        public async Task UpdateAsync(Om o)
+        {
+            _db.Om.Update(o);
+            await _db.SaveChangesAsync();
+        }
+
+        public Task<List<Om>> GetAllAsync() =>
+            _db.Om.ToListAsync();
+
+        public async Task DeleteAsync(int id)
+        {
+            var o = await _db.Om.FindAsync(id);
+            if (o != null)
+            {
+                _db.Om.Remove(o);
+                await _db.SaveChangesAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DbSet for Donation in ApplicationDbContext
- implement CRUD services for Donation, Kontakt, and Om models

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cae93a6788325ab40734d4b134e94