### PR TITLE
Ensure session has backing store

### DIFF
--- a/ForeningWeb.Tests/SessionTests.cs
+++ b/ForeningWeb.Tests/SessionTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Caching.Distributed;
+using Xunit;
+
+namespace ForeningWeb.Tests
+{
+    public class SessionTests
+    {
+        [Fact]
+        public void Session_Registers_DistributedCache()
+        {
+            var services = new ServiceCollection();
+            services.AddDistributedMemoryCache();
+            services.AddSession();
+
+            var provider = services.BuildServiceProvider();
+            var cache = provider.GetService<IDistributedCache>();
+
+            Assert.NotNull(cache);
+        }
+    }
+}

--- a/ForeningWeb/Program.cs
+++ b/ForeningWeb/Program.cs
@@ -15,6 +15,7 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // ---------- Services ----------
+builder.Services.AddDistributedMemoryCache();
 builder.Services.AddSession();
 
 // Database


### PR DESCRIPTION
## Summary
- configure distributed memory cache so session can start without runtime errors
- test that session registration provides an `IDistributedCache`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb1dc7a88325a5c6780c134ffc6b