### PR TITLE
Restrict admin-only page actions

### DIFF
--- a/ForeningWeb/Pages/About/Details.cshtml
+++ b/ForeningWeb/Pages/About/Details.cshtml
@@ -10,6 +10,9 @@
     <strong>Billede:</strong> @Model.Item?.BilledePath
 </div>
 <div>
-    <a asp-page="Edit" asp-route-id="@Model.Item?.Id">Rediger</a> |
+    @if (User.HasClaim("role", "admin"))
+    {
+        <a asp-page="Edit" asp-route-id="@Model.Item?.Id">Rediger</a> |
+    }
     <a asp-page="Index">Tilbage</a>
 </div>

--- a/ForeningWeb/Pages/About/Index.cshtml
+++ b/ForeningWeb/Pages/About/Index.cshtml
@@ -2,8 +2,10 @@
 @model ForeningWeb.Pages.About.IndexModel
 
 <h1>Om</h1>
-
-<p><a asp-page="Create">Opret ny</a></p>
+@if (User.HasClaim("role", "admin"))
+{
+    <p><a asp-page="Create">Opret ny</a></p>
+}
 
 <table class="table">
     <thead>
@@ -18,9 +20,15 @@
         <tr>
             <td>@item.Indhold</td>
             <td>
-                <a asp-page="Edit" asp-route-id="@item.Id">Rediger</a> |
-                <a asp-page="Details" asp-route-id="@item.Id">Detaljer</a> |
-                <a asp-page="Delete" asp-route-id="@item.Id">Slet</a>
+                @if (User.HasClaim("role", "admin"))
+                {
+                    <a asp-page="Edit" asp-route-id="@item.Id">Rediger</a> |
+                }
+                <a asp-page="Details" asp-route-id="@item.Id">Detaljer</a>
+                @if (User.HasClaim("role", "admin"))
+                {
+                    | <a asp-page="Delete" asp-route-id="@item.Id">Slet</a>
+                }
             </td>
         </tr>
 }

--- a/ForeningWeb/Pages/Contacts/Details.cshtml
+++ b/ForeningWeb/Pages/Contacts/Details.cshtml
@@ -16,6 +16,9 @@
     <strong>Adresse:</strong> @Model.Item?.Adresse
 </div>
 <div>
-    <a asp-page="Edit" asp-route-id="@Model.Item?.Id">Rediger</a> |
+    @if (User.HasClaim("role", "admin"))
+    {
+        <a asp-page="Edit" asp-route-id="@Model.Item?.Id">Rediger</a> |
+    }
     <a asp-page="Index">Tilbage</a>
 </div>

--- a/ForeningWeb/Pages/Contacts/Index.cshtml
+++ b/ForeningWeb/Pages/Contacts/Index.cshtml
@@ -2,8 +2,10 @@
 @model ForeningWeb.Pages.Contacts.IndexModel
 
 <h1>Kontakter</h1>
-
-<p><a asp-page="Create">Opret ny</a></p>
+@if (User.HasClaim("role", "admin"))
+{
+    <p><a asp-page="Create">Opret ny</a></p>
+}
 
 <table class="table">
     <thead>
@@ -22,9 +24,15 @@
             <td>@item.Email</td>
             <td>@item.Telefon</td>
             <td>
-                <a asp-page="Edit" asp-route-id="@item.Id">Rediger</a> |
-                <a asp-page="Details" asp-route-id="@item.Id">Detaljer</a> |
-                <a asp-page="Delete" asp-route-id="@item.Id">Slet</a>
+                @if (User.HasClaim("role", "admin"))
+                {
+                    <a asp-page="Edit" asp-route-id="@item.Id">Rediger</a> |
+                }
+                <a asp-page="Details" asp-route-id="@item.Id">Detaljer</a>
+                @if (User.HasClaim("role", "admin"))
+                {
+                    | <a asp-page="Delete" asp-route-id="@item.Id">Slet</a>
+                }
             </td>
         </tr>
 }

--- a/ForeningWeb/Pages/Donations/Details.cshtml
+++ b/ForeningWeb/Pages/Donations/Details.cshtml
@@ -10,6 +10,9 @@
     <strong>Besked:</strong> @Model.Item?.Besked
 </div>
 <div>
-    <a asp-page="Edit" asp-route-id="@Model.Item?.Id">Rediger</a> |
+    @if (User.HasClaim("role", "admin"))
+    {
+        <a asp-page="Edit" asp-route-id="@Model.Item?.Id">Rediger</a> |
+    }
     <a asp-page="Index">Tilbage</a>
 </div>

--- a/ForeningWeb/Pages/Donations/Index.cshtml
+++ b/ForeningWeb/Pages/Donations/Index.cshtml
@@ -2,8 +2,10 @@
 @model ForeningWeb.Pages.Donations.IndexModel
 
 <h1>Donationer</h1>
-
-<p><a asp-page="Create">Opret ny</a></p>
+@if (User.HasClaim("role", "admin"))
+{
+    <p><a asp-page="Create">Opret ny</a></p>
+}
 
 <table class="table">
     <thead>
@@ -20,9 +22,15 @@
             <td>@item.MobilePayNummer</td>
             <td>@item.Besked</td>
             <td>
-                <a asp-page="Edit" asp-route-id="@item.Id">Rediger</a> |
-                <a asp-page="Details" asp-route-id="@item.Id">Detaljer</a> |
-                <a asp-page="Delete" asp-route-id="@item.Id">Slet</a>
+                @if (User.HasClaim("role", "admin"))
+                {
+                    <a asp-page="Edit" asp-route-id="@item.Id">Rediger</a> |
+                }
+                <a asp-page="Details" asp-route-id="@item.Id">Detaljer</a>
+                @if (User.HasClaim("role", "admin"))
+                {
+                    | <a asp-page="Delete" asp-route-id="@item.Id">Slet</a>
+                }
             </td>
         </tr>
 }


### PR DESCRIPTION
## Summary
- Hide create, edit, and delete links on Donations, Contacts, and About pages unless user has admin claim
- Keep details/return navigation visible for all users

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: repository not signed, package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d0226c8188325bfae36987f1a3cc2